### PR TITLE
Major perf improvement by decorating unsafe functions with AES target.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ impl MeowLane {
 }
 
 #[inline]
+#[target_feature(enable="aes")]
 unsafe fn aes_rotate(a: &mut MeowLane, b: &mut MeowLane) {
     a.l0 = _mm_aesdec_si128(a.l0, b.l0);
     a.l1 = _mm_aesdec_si128(a.l1, b.l1);
@@ -71,6 +72,7 @@ unsafe fn aes_rotate(a: &mut MeowLane, b: &mut MeowLane) {
 
 #[inline]
 #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+#[target_feature(enable="aes")]
 unsafe fn aes_load(s: &mut MeowLane, from: *const u8) {
     s.l0 = _mm_aesdec_si128(s.l0, ptr::read_unaligned(from as *const __m128i));
     s.l1 = _mm_aesdec_si128(
@@ -88,6 +90,7 @@ unsafe fn aes_load(s: &mut MeowLane, from: *const u8) {
 }
 
 #[inline]
+#[target_feature(enable="aes")]
 unsafe fn aes_merge(a: &mut MeowLane, b: &MeowLane) {
     a.l0 = _mm_aesdec_si128(a.l0, b.l0);
     a.l1 = _mm_aesdec_si128(a.l1, b.l1);


### PR DESCRIPTION
This enables inlining of the AES intrinsics and fixes the big performance difference in the C version as discussed in #1. 

`test digest_3_1m` benchmark went from 110,758 ns to 38,966 ns (8850 -> 26069 MB/s) on my MBP13, which is very nice!

Big thanks to @bitshifter for suggesting this was the cause of the perf delta.