### PR TITLE
Re-export digest crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ use core::{
     mem::{self, MaybeUninit},
     sync::atomic::{fence, Ordering},
 };
+pub use digest;
 use digest::generic_array::{
     typenum::{consts::*, Unsigned},
     GenericArray,


### PR DESCRIPTION
In order to interact with `meowhash::MeowHasher` functions implementing
`digest::Digest` (required, for example, to calculate the hash of a
stream without buffering it in-memory entirely), it's necessary for
downstream users to `use digest::Digest` to gain access to the impl.

There are two problems:
1) `meowhash` users need to add _two_ dependencies to their `Cargo.toml`
   file in order to use this crate (a dependency on `meowhash` and a
   dependency on `digest`), and
2) It's insufficient to just (also) add a dependency on `digest`, you
   have to find out what version `meowhash` is using internally and
   match that version when declaring the dependency, otherwise two
   versions of the `digest` crate end up being used: one being the
   version `meowhash` depends on, and the other being the `digest`
   version pulled in by the updated `Cargo.toml`. They're incompatible,
   so putting `use digest::Digest` in your code and then trying to use
   `<MeowHasher as Digest>::update(...)` causes rustc to emit errors
   because `MeowHasher` doesn't actually implement the same
   `digest::Digest` that one is using.
3) Even if you did match your `digest` dependency against that used by
   `meowhash`, if you ever `cargo upgrade` there's a very good chance
   everything will break again.

The solution for this in the rust ecosystem is to `pub use` your
external dependency. You could probably get away with just `pub use
digest::Digest` instead of `pub use digest` since the latest version of
`meowhash` doesn't expose any `digest` API members other than the
`Digest` trait (`generic_array` is no longer exposed), but just
re-exporting the entire crate seems to be the preferred approach in the
crate ecosystem and it's less of a maintenance burden down the line (in
case you do end up using something else from the `digest` crate in your
public API once again).